### PR TITLE
Bump Dash to 0.2.3

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ runs:
         - uses: montudor/action-zip@v1
         - uses: bridge-core/setup-dash@main
           with:
-            dash-version: 0.2.2
+            dash-version: 0.2.3
         - run: dash_compiler build -c ${{ inputs.compiler-config }}
           shell: bash
         - run: |


### PR DESCRIPTION
Updates version of dash compiler to v0.2.3 which is the latest on deno x